### PR TITLE
Address a few nuanced-TODOs

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -29,6 +29,12 @@ func TestContext_Errors(t *testing.T) {
 
 	ctx.pop()
 	is.Equal(err, ctx.Err(), "error should be propogated to parent")
+
+	ctx.SetErr(nil)
+	is.Equal(err, ctx.Err(), "errors cannot be unset via SetErr")
+
+	ctx.unsetErr()
+	is.NoError(ctx.Err(), "errors can only be unset via unsetErr")
 }
 
 func TestContext_GetSet(t *testing.T) {

--- a/failable_test.go
+++ b/failable_test.go
@@ -99,9 +99,20 @@ func TestFailable_Rollback_Failure(t *testing.T) {
 	is.False(cmdC.rolledBack)
 }
 
-func TestFailable_DryRun(t *testing.T) {
+func TestFailable_DryRun_Success(t *testing.T) {
 	is := assert.New(t)
 	cmd := &MockCommand{name: "foo"}
 	DryRun(MakeFailable(cmd))
+	is.True(cmd.dryRan)
+}
+
+func TestFailable_DryRun_Failure(t *testing.T) {
+	is := assert.New(t)
+	cmd := &MockCommand{name: "foo", err: errors.New("bar")}
+
+	ctx := NewContext()
+	MakeFailable(cmd).(*failable).DryRun(ctx, DefaultPrinter)
+
+	is.NoError(ctx.Err())
 	is.True(cmd.dryRan)
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -16,7 +16,8 @@ type Command interface {
 }
 
 // Rollbacker can be implemented by Commands that are reversible in the event of a downstream failure. A Rollbacker
-// will have access to the same Context when the Command's Run method was executed.
+// will have access to the same Context when the Command's Run method was executed. The error that triggered the
+// rollback may not be available in the Context, so its value should not be relied upon.
 //
 // Commands that don't implement Rollbacker will be skipped over during a rollback; they will not halt the execution.
 type Rollbacker interface {

--- a/sequence.go
+++ b/sequence.go
@@ -35,7 +35,6 @@ func (s *sequence) Rollback(ctx Context, p Printer) {
 	ctx.pop()
 }
 
-// TODO: DryRun should halt execution if a command fails
 func (s *sequence) DryRun(ctx Context, p Printer) {
 	s.dryRunSubCommands(ctx, p, s.cmds)
 }
@@ -85,7 +84,7 @@ func (s *sequence) rollbackSubCommands(ctx Context, p Printer, cmds []Command) {
 }
 
 func (s *sequence) dryRunSubCommands(ctx Context, p Printer, cmds []Command) {
-	if len(cmds) == 0 {
+	if len(cmds) == 0 || ctx.Err() != nil {
 		return
 	}
 

--- a/sequence_test.go
+++ b/sequence_test.go
@@ -104,6 +104,25 @@ func TestSequence_DryRun_Success(t *testing.T) {
 	is.NoError(ctx.Err())
 }
 
+func TestSequence_DryRun_Fail(t *testing.T) {
+	is := assert.New(t)
+	err := errors.New("foobar")
+
+	cmdA := &MockCommand{name: "A"}
+	cmdB := &MockCommand{name: "B", err: err}
+	cmdC := &MockCommand{name: "C"}
+
+	ctx := NewContext()
+	seq := NewSequence(cmdA, cmdB, cmdC).(*sequence)
+	seq.DryRun(ctx, DefaultPrinter)
+
+	is.Equal(err, ctx.Err())
+	is.True(cmdA.dryRan)
+	is.True(cmdB.dryRan)
+	is.True(cmdB.failed)
+	is.False(cmdC.dryRan)
+}
+
 func TestSequence_Rollback_EmptySequence(t *testing.T) {
 	is := assert.New(t)
 	p, out := getTestPrinter()

--- a/subcontext.go
+++ b/subcontext.go
@@ -13,11 +13,7 @@ func newSubContext(parent Context) Context {
 }
 
 func (sc *subCtx) Err() error {
-	err := sc.ctx.Err()
-	if sc.ctx.Err() == nil {
-		err = sc.parent.Err()
-	}
-	return err
+	return sc.ctx.Err()
 }
 
 func (sc *subCtx) SetErr(err error) {
@@ -41,4 +37,8 @@ func (sc *subCtx) push() {
 
 func (sc *subCtx) pop() {
 	sc.ctx.pop()
+}
+
+func (sc *subCtx) unsetErr() {
+	sc.ctx.unsetErr()
 }

--- a/subcontext_test.go
+++ b/subcontext_test.go
@@ -30,13 +30,19 @@ func TestSubContext_Errors(t *testing.T) {
 	sctx.SetErr(err)
 	is.Equal(err, sctx.Err(), "child subcontexts should see set error")
 
+	sctx.SetErr(nil)
+	is.Equal(err, sctx.Err(), "subcontext errors cannot be unset via SetErr")
+
 	sctx.pop()
 	is.Equal(err, sctx.Err(), "error should propogate to subcontext parent")
 	is.NoError(ctx.Err(), "parent context should not see errors in subcontext")
 
+	sctx.unsetErr()
+	is.NoError(sctx.Err(), "subcontext errors can only be unset via unsetErr")
+
 	ctx.SetErr(err)
 	sctx = newSubContext(ctx)
-	is.Equal(err, sctx.Err(), "subcontext should see parent errors")
+	is.NoError(sctx.Err(), "subcontext should not see parent errors")
 }
 
 func TestSubContext_GetSet(t *testing.T) {


### PR DESCRIPTION
+ Don't allow non-failable commands from unsetting the Context error
+ Isolate parent context errors from subcommand errors for Rollbacks
+ DryRuns should terminate if an error is encountered, accounted for in
Sequence, Failable and Parallel.