### PR TITLE
Fix extra pop on Sequence Rollback.

### DIFF
--- a/mocks_test.go
+++ b/mocks_test.go
@@ -6,6 +6,11 @@ type MockCommand struct {
 	name string
 	err  error
 
+	set string
+	see string
+
+	setVal     bool
+	seenVal    bool
 	ran        bool
 	failed     bool
 	rolledBack bool
@@ -19,17 +24,22 @@ func (c *MockCommand) String() string {
 func (c *MockCommand) Run(ctx Context, p Printer) {
 	p.Info("MOCK running %s", c.name)
 	c.ran = true
+	c.maybeSetVal(ctx, p)
+	c.maybeSeeVal(ctx, p)
 	c.maybeFail(ctx, p)
 }
 
 func (c *MockCommand) Rollback(ctx Context, p Printer) {
 	p.Info("MOCK rolling back %s", c.name)
 	c.rolledBack = true
+	c.maybeSeeVal(ctx, p)
 }
 
 func (c *MockCommand) DryRun(ctx Context, p Printer) {
 	p.Info("MOCK dry run %s", c.name)
 	c.dryRan = true
+	c.maybeSetVal(ctx, p)
+	c.maybeSeeVal(ctx, p)
 	c.maybeFail(ctx, p)
 }
 
@@ -38,5 +48,21 @@ func (c *MockCommand) maybeFail(ctx Context, p Printer) {
 		p.Err("MOCK error %s: %v", c.name, c.err)
 		c.failed = true
 		ctx.SetErr(c.err)
+	}
+}
+
+func (c *MockCommand) maybeSetVal(ctx Context, p Printer) {
+	if c.set != "" {
+		ctx.Set(c.set, c.name)
+		c.setVal = true
+	}
+}
+
+func (c *MockCommand) maybeSeeVal(ctx Context, p Printer) {
+	if c.see != "" {
+		_, c.seenVal = ctx.Get(c.see)
+		if !c.seenVal {
+			p.Warn("Didn't see: %s", c.see)
+		}
 	}
 }

--- a/sequence.go
+++ b/sequence.go
@@ -71,10 +71,10 @@ func (s *sequence) rollbackSubCommands(ctx Context, p Printer, cmds []Command) {
 		return
 	}
 
-	ctx.pop()
 	if cmd, ok := cmds[len(cmds)-1].(Rollbacker); ok {
 		cmd.Rollback(ctx, p)
 	}
+	ctx.pop()
 
 	if len(cmds) == 1 {
 		return


### PR DESCRIPTION
If a Sequence was within another Sequence and needed to rollback, an
extra context was popped, causing mis-alignment between Commands and
Context.